### PR TITLE
Drop extra yum update and clean up temp yum files from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ARG VERSION
 FROM amazoncorretto:$VERSION
 
-RUN yum update -y && yum update ca-certificates && yum install -y tar gzip procps
-RUN curl -L https://github.com/patric-r/jvmtop/releases/download/0.8.0/jvmtop-0.8.0.tar.gz | tar xz \
- && chmod +x jvmtop.sh \
- && mv jvmtop.jar /usr/local/bin/ \
- && mv jvmtop.sh /usr/local/bin/jvmtop
+RUN yum update -y \
+    && yum install -y tar gzip procps \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && curl -L https://github.com/patric-r/jvmtop/releases/download/0.8.0/jvmtop-0.8.0.tar.gz | tar xz \
+    && chmod +x jvmtop.sh \
+    && mv jvmtop.jar /usr/local/bin/ \
+    && mv jvmtop.sh /usr/local/bin/jvmtop


### PR DESCRIPTION
cleaning up the yum cache reduces the size of the uncompressed image from 800 to 500 MB.

~This also solves several critical and high vulnerabilities I identified with trivy in the latest image available (see [this comment](https://github.com/seqeralabs/devops-backlog/issues/166#issuecomment-1508639603))~ I was looking at an old container registry, the latest image from Harbor is fine