### PR TITLE
Point docker repo to aws

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM amazoncorretto:$VERSION
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:$VERSION
 
 ADD wait-for-it.sh /usr/local/bin/
 

--- a/Dockerfile_jemalloc
+++ b/Dockerfile_jemalloc
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM amazoncorretto:$VERSION as build
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:$VERSION as build
 
 RUN yum install -y bzip2 \
  && yum groupinstall -y "Development Tools"


### PR DESCRIPTION
Amazon Linux and Amazon Coretto images are first published to Public ECR and then to Docker Hub. The delay is quite high:

Docker Hub:
<img width="306" alt="image" src="https://github.com/user-attachments/assets/ac071f97-11f0-447a-87e1-992fee076309" />

Amazon ECR:
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/4d51b061-6591-45f3-9446-5e28882bb9de" />

My proposal is to build images directly from Public ECR. 