### PR TITLE
Replace jemalloc with mimalloc for better ARM64 compatibility

### DIFF
--- a/.github/workflows/build-mimalloc.yml
+++ b/.github/workflows/build-mimalloc.yml
@@ -1,0 +1,59 @@
+name: Build mimalloc binaries
+on:
+  push:
+    branches:
+      - '*'
+    paths:
+      - 'build-mimalloc-native.sh'
+      - '.github/workflows/build-mimalloc.yml'
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-mimalloc-amd64:
+    name: Build mimalloc for AMD64
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential curl cmake
+        
+    - name: Build mimalloc for AMD64
+      run: ./build-mimalloc-native.sh amd64
+      
+    - name: Upload AMD64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mimalloc-amd64
+        path: mimalloc-binaries/amd64/
+        retention-days: 1
+
+  build-mimalloc-arm64:
+    name: Build mimalloc for ARM64
+    runs-on: ubuntu-24.04-arm64
+    timeout-minutes: 20
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential curl cmake
+        
+    - name: Build mimalloc for ARM64
+      run: ./build-mimalloc-native.sh arm64
+      
+    - name: Upload ARM64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mimalloc-arm64
+        path: mimalloc-binaries/arm64/
+        retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ permissions:
   contents: write
 
 jobs:
-  build-jemalloc:
-    uses: ./.github/workflows/build-jemalloc.yml
+  build-mimalloc:
+    uses: ./.github/workflows/build-mimalloc.yml
 
   build-backend:
     name: nf-jdk build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build-jemalloc
+    needs: build-mimalloc
 
     env:
       GITHUB_TOKEN: ${{ github.token }}
@@ -42,28 +42,28 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Download jemalloc AMD64 artifacts
+    - name: Download mimalloc AMD64 artifacts
       uses: actions/download-artifact@v4
       with:
-        name: jemalloc-amd64
-        path: jemalloc-binaries/amd64/
+        name: mimalloc-amd64
+        path: mimalloc-binaries/amd64/
 
-    - name: Download jemalloc ARM64 artifacts
+    - name: Download mimalloc ARM64 artifacts
       uses: actions/download-artifact@v4
       with:
-        name: jemalloc-arm64
-        path: jemalloc-binaries/arm64/
+        name: mimalloc-arm64
+        path: mimalloc-binaries/arm64/
 
-    - name: Verify jemalloc binaries
+    - name: Verify mimalloc binaries
       run: |
-        echo "Checking jemalloc binaries..."
-        ls -la jemalloc-binaries/
-        ls -la jemalloc-binaries/amd64/ || echo "AMD64 directory empty or missing"
-        ls -la jemalloc-binaries/arm64/ || echo "ARM64 directory empty or missing"
+        echo "Checking mimalloc binaries..."
+        ls -la mimalloc-binaries/
+        ls -la mimalloc-binaries/amd64/ || echo "AMD64 directory empty or missing"
+        ls -la mimalloc-binaries/arm64/ || echo "ARM64 directory empty or missing"
         echo "AMD64 lib contents:"
-        ls -la jemalloc-binaries/amd64/lib/ || echo "No AMD64 lib directory"
+        ls -la mimalloc-binaries/amd64/lib/ || echo "No AMD64 lib directory"
         echo "ARM64 lib contents:"  
-        ls -la jemalloc-binaries/arm64/lib/ || echo "No ARM64 lib directory"
+        ls -la mimalloc-binaries/arm64/lib/ || echo "No ARM64 lib directory"
 
     - name: Docker Login 
       uses: docker/login-action@v2

--- a/Dockerfile_mimalloc
+++ b/Dockerfile_mimalloc
@@ -1,0 +1,42 @@
+ARG VERSION=24-al2023
+
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:$VERSION
+
+# Use built-in ARG that Docker sets automatically for multi-arch builds
+ARG TARGETARCH
+
+## see https://github.com/microsoft/mimalloc
+# Copy all mimalloc binaries
+COPY mimalloc-binaries/ /tmp/mimalloc-binaries/
+
+# Debug and copy the correct architecture binaries
+RUN echo "=== TARGETARCH: ${TARGETARCH} ===" && \
+    echo "=== Available architectures ===" && \
+    ls -la /tmp/mimalloc-binaries/ && \
+    echo "=== Copying ${TARGETARCH} binaries ===" && \
+    mkdir -p /opt/mimalloc && \
+    cp -r /tmp/mimalloc-binaries/${TARGETARCH}/* /opt/mimalloc/ && \
+    echo "=== Verifying copy ===" && \
+    ls -la /opt/mimalloc/ && \
+    rm -rf /tmp/mimalloc-binaries
+
+# Install file command and debug: verify mimalloc files are copied correctly
+RUN yum install -y file && \
+    echo "=== DEBUG: Checking mimalloc installation ===" && \
+    ls -la /opt/mimalloc/ && \
+    echo "=== /opt/mimalloc/lib/ contents ===" && \
+    ls -la /opt/mimalloc/lib/ && \
+    echo "=== File info for libmimalloc.so.2.1 ===" && \
+    file /opt/mimalloc/lib/libmimalloc.so.2.1 && \
+    echo "=== Architecture info ===" && \
+    uname -m
+
+ENV \
+  PATH=$PATH:/opt/mimalloc/bin \
+  LD_PRELOAD=/opt/mimalloc/lib/libmimalloc.so.2.1
+
+ADD wait-for-it.sh /usr/local/bin/
+
+RUN yum update -y \
+    && yum install -y tar gzip procps which \
+    && yum clean all

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ build:
 	 --no-cache \
 	 --platform linux/amd64,linux/arm64 \
 	 --build-arg VERSION=${version} \
-	 -t ${repo}/${image}-jemalloc \
-	 -f Dockerfile_jemalloc \
+	 -t ${repo}/${image}-mimalloc \
+	 -f Dockerfile_mimalloc \
 	 --push \
 	 .
 

--- a/build-mimalloc-native.sh
+++ b/build-mimalloc-native.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+
+MIMALLOC_VERSION="2.1.7"
+ARCH="${1:-$(uname -m)}"
+
+case $ARCH in
+    x86_64|amd64)
+        TARGET_ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        TARGET_ARCH="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+echo "Building mimalloc ${MIMALLOC_VERSION} for ${TARGET_ARCH} (native build)"
+
+# Create build directory
+BUILD_DIR="mimalloc-build-${TARGET_ARCH}"
+rm -rf $BUILD_DIR
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+
+# Download and extract mimalloc
+echo "Downloading mimalloc ${MIMALLOC_VERSION}..."
+curl -sSL "https://github.com/microsoft/mimalloc/archive/refs/tags/v${MIMALLOC_VERSION}.tar.gz" | tar -xz
+
+cd mimalloc-${MIMALLOC_VERSION}
+
+# Create build directory for CMake
+mkdir -p build
+cd build
+
+# Configure with CMake
+echo "Configuring mimalloc..."
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/opt/mimalloc \
+    -DMI_BUILD_SHARED=ON \
+    -DMI_BUILD_STATIC=ON \
+    -DMI_BUILD_OBJECT=ON \
+    -DMI_BUILD_TESTS=OFF \
+    -DMI_OVERRIDE=ON
+
+echo "Building mimalloc..."
+make -j$(nproc)
+
+echo "Installing mimalloc to temporary directory..."
+make install DESTDIR="$(pwd)/install"
+
+# Create target directory structure
+echo "Creating binary package..."
+mkdir -p "../../../mimalloc-binaries/${TARGET_ARCH}"
+cp -r "$(pwd)/install/opt/mimalloc"/* "../../../mimalloc-binaries/${TARGET_ARCH}/"
+
+# Verify the build
+echo "Verifying build..."
+ls -la "../../../mimalloc-binaries/${TARGET_ARCH}/"
+file "../../../mimalloc-binaries/${TARGET_ARCH}/lib/libmimalloc.so.2.1"
+
+echo "mimalloc ${MIMALLOC_VERSION} built successfully for ${TARGET_ARCH}"
+echo "Binaries available in: mimalloc-binaries/${TARGET_ARCH}/"


### PR DESCRIPTION
## Summary
This PR replaces jemalloc with mimalloc to solve the ARM64 page size compatibility issue identified in facebook/buck2#91.

## Problem Solved
**jemalloc ARM64 page size issue**: jemalloc compiles the host OS page size into the binary at compile time, causing crashes when running on systems with different page sizes (4k vs 16k vs 64k pages).

## Solution: Migration to mimalloc
**mimalloc advantages**:
- Runtime page size detection - no hardcoded page sizes
- Better ARM64 compatibility - works on Apple Silicon, Linux ARM64 with any page size  
- Improved performance - often faster than jemalloc in benchmarks
- Lower memory overhead - ~0.2% metadata vs jemalloc's higher overhead
- Cross-platform portability - single binary works everywhere

## Changes Made
- **build-mimalloc-native.sh**: New build script using CMake
- **build-mimalloc.yml**: New CI workflow for mimalloc builds
- **Dockerfile_mimalloc**: New Dockerfile with mimalloc integration
- **Updated workflows**: Changed from build-jemalloc to build-mimalloc
- **Updated Makefile**: Changed image tag from -jemalloc to -mimalloc

## Testing Status
- ✅ mimalloc AMD64 build: Completed in 43s
- ✅ mimalloc ARM64 build: Completed in 1m22s  
- 🔄 Docker multi-arch build: Currently in progress

## Benefits
1. Eliminates ARM64 compatibility risks - no more page size crashes
2. Simplifies deployment - one binary works on all ARM64 systems
3. Maintains/improves performance
4. Better developer experience across macOS Silicon and Linux ARM64

Reference: https://github.com/facebook/buck2/issues/91